### PR TITLE
Clarify in the deprecation README that AMD ROCm support is not yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 > [!CAUTION]
 > The ROCm/Stanford-Megatron-LM repository is retired, please use the [upstream](https://github.com/stanford-futuredata/Megatron-LM) repository
 >
+
+> [!NOTE]
+> AMD ROCm support is **not yet available in the upstream** [stanford-futuredata/Megatron-LM](https://github.com/stanford-futuredata/Megatron-LM) repository.
+> The pull request [stanford-futuredata/Megatron-LM#7](https://github.com/stanford-futuredata/Megatron-LM/pull/7) brings AMD ROCm support to upstream.
+>


### PR DESCRIPTION
Clarify in the deprecation README that AMD ROCm support is not yet with latest Upstream PR